### PR TITLE
excluded example package from build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.thalmic.myo.example.HelloMyo</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/com/thalmic/myo/example/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+				</executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -71,6 +77,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>*.example.*</excludePackageNames>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Hello Nicholas,

I extended the `pom.xml` to enhance the build process. Withit the example package will be excluded from the jar build and javadoc generation. So, the result is a build, which includes only the relevant sources of the library.

Happy coding,
Darius
